### PR TITLE
Fix issue with memory exhaustion on complex pages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,16 @@
 Changelog
 =========
+
+0.9.30 (unreleased)
+-------------------
+
+- fix issue where a page constructed with many of the same snippets and a
+  snippet that contained the same markup as the page could cause huge
+  page output. We had a server using up 16 gigs of RAM trying to render
+  a complex page and then crashing the process.
+  [vangheem]
+
+
 0.9.29 (12/19/2014)
 -------------------
 - Users can now reenable tinyMCE after disabling it

--- a/src/uwosh/snippets/parser.py
+++ b/src/uwosh/snippets/parser.py
@@ -1,41 +1,44 @@
 # -*- coding: utf-8 -*-
 import re
-from plone.registry import field
-from plone.registry.record import Record
-from zope.component import getUtility
-from plone.registry.interfaces import IRegistry
 from string import replace
-
-from Products.CMFCore.utils import getToolByName
-
 from uwosh.snippets.snippetmanager import SnippetManager
 
+
 class SnippetParser():
-	#The SnippetParser class handles the finding/replacing of snippets within a pages content.
-	#The page content is passed to a Parser object, and it then tries to pattern match 
-	#the <span> tags used to represent snippets. If it finds a valid snippet tag, 
-	#it replaces it with the appropriate snippet text. 
+    # The SnippetParser class handles the finding/replacing of snippets within a pages content.
+    # The page content is passed to a Parser object, and it then tries to pattern match
+    # the <span> tags used to represent snippets. If it finds a valid snippet tag,
+    # it replaces it with the appropriate snippet text.
 
-	def __init__(self):
-		self.sm = SnippetManager()
+    def __init__(self):
+        self.sm = SnippetManager()
 
-	snippetRegex = '<span(?=[^>]*?data-type="snippet_tag"\s*)(?=[^>]*?data-snippet-id="([a-zA-Z0-9\s_-]+?)"\s*)[^>]+?>[^<>]*?<\/span>'
+    snippetRegex = '<span(?=[^>]*?data-type="snippet_tag"\s*)(?=[^>]*?data-snippet-id="([a-zA-Z0-9\s_-]+?)"\s*)[^>]+?>[^<>]*?<\/span>'  # noqa
 
-	def parsePage(self, pageText):
-		result = self.parseSnippets(pageText)
+    def parsePage(self, pageText):
+        result = self.parseSnippets(pageText)
 
-		return result
+        return result
 
-	def parseSnippets(self, pageText):
-		pattern = re.compile(self.snippetRegex)
-		matches = pattern.finditer(pageText)
+    def parseSnippets(self, pageText):
+        pattern = re.compile(self.snippetRegex)
+        matches = pattern.finditer(pageText)
 
-		snippets = self.sm.getSnippets(True)
-		for match in matches:
-			try:
-				pageText = replace(pageText, match.group(0), snippets[match.group(1)].getText())
-			except KeyError:
-				#The snippetID was invalid
-				pageText = replace(pageText, match.group(0), '')
+        snippets = self.sm.getSnippets(True)
+        rendered = {}
+        matches = []
+        for match in matches:
+            replace_text = match.group(0)
+            snippet_name = match.group(1)
+            if replace_text in matches:
+                continue
+            try:
+                if snippet_name not in rendered:
+                    rendered[snippet_name] = snippets[snippet_name].getText()
+                pageText = replace(pageText, replace_text, rendered[snippet_name])
+                matches.append(replace_text)
+            except KeyError:
+                # The snippetID was invalid
+                pageText = replace(pageText, match.group(0), '')
 
-		return pageText
+        return pageText


### PR DESCRIPTION
fix issue where a page constructed with many of the same snippets and a  snippet that contained the same markup as the page could cause huge
  page output. We had a server using up 16 gigs of RAM trying to render
  a complex page and then crashing the process.